### PR TITLE
rfc8785: ensure IntEnum works on < 3.11

### DIFF
--- a/src/rfc8785/_impl.py
+++ b/src/rfc8785/_impl.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import math
 import re
+from enum import IntEnum
 from io import BytesIO
 from typing import IO
 
@@ -189,6 +190,12 @@ def dump(obj: _Value, sink: IO[bytes]) -> None:
             else:
                 sink.write(b"false")
         case int():
+            # Annoyance: IntEnum is an int, but prior to 3.11 str(IntEnum)
+            # returns the field repr and not the int itself. Unwrap it.
+            # TODO: Remove this after 3.10 is dropped.
+            if isinstance(obj, IntEnum):
+                obj = obj.value
+
             if obj < _INT_MIN or obj > _INT_MAX:
                 raise IntegerDomainError(obj)
             sink.write(str(obj).encode("utf-8"))

--- a/src/rfc8785/_impl.py
+++ b/src/rfc8785/_impl.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import math
 import re
-from enum import IntEnum
 from io import BytesIO
 from typing import IO
 
@@ -190,11 +189,10 @@ def dump(obj: _Value, sink: IO[bytes]) -> None:
             else:
                 sink.write(b"false")
         case int():
-            # Annoyance: IntEnum is an int, but prior to 3.11 str(IntEnum)
-            # returns the field repr and not the int itself. Unwrap it.
-            # TODO: Remove this after 3.10 is dropped.
-            if isinstance(obj, IntEnum):
-                obj = obj.value
+            # Annoyance: int can be subclassed by types like IntEnum,
+            # which then break or change `int.__str__`. Rather than plugging
+            # these individually, we coerce back to `int`.
+            obj = int(obj)
 
             if obj < _INT_MIN or obj > _INT_MAX:
                 raise IntegerDomainError(obj)

--- a/test/test_impl.py
+++ b/test/test_impl.py
@@ -5,6 +5,7 @@ Internal implementation tests.
 import gzip
 import json
 import struct
+import sys
 from enum import IntEnum, StrEnum
 from io import BytesIO
 
@@ -114,6 +115,7 @@ def test_dumps_intenum():
     assert json.loads(raw) == [1, 2, 9001]
 
 
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="StrEnum added in 3.11+")
 def test_dumps_strenum():
     # StrEnum is a subclass of str, so this should work transparently.
     class X(StrEnum):

--- a/test/test_impl.py
+++ b/test/test_impl.py
@@ -6,7 +6,7 @@ import gzip
 import json
 import struct
 import sys
-from enum import IntEnum, StrEnum
+from enum import IntEnum
 from io import BytesIO
 
 import pytest
@@ -117,6 +117,8 @@ def test_dumps_intenum():
 
 @pytest.mark.skipif(sys.version_info < (3, 11), reason="StrEnum added in 3.11+")
 def test_dumps_strenum():
+    from enum import StrEnum
+
     # StrEnum is a subclass of str, so this should work transparently.
     class X(StrEnum):
         A = "foo"

--- a/test/test_impl.py
+++ b/test/test_impl.py
@@ -5,7 +5,7 @@ Internal implementation tests.
 import gzip
 import json
 import struct
-from enum import IntEnum
+from enum import IntEnum, StrEnum
 from io import BytesIO
 
 import pytest
@@ -112,3 +112,14 @@ def test_dumps_intenum():
 
     raw = impl.dumps([X.A, X.B, X.C])
     assert json.loads(raw) == [1, 2, 9001]
+
+
+def test_dumps_strenum():
+    # StrEnum is a subclass of str, so this should work transparently.
+    class X(StrEnum):
+        A = "foo"
+        B = "bar"
+        C = "baz"
+
+    raw = impl.dumps([X.A, X.B, X.C])
+    assert json.loads(raw) == ["foo", "bar", "baz"]


### PR DESCRIPTION
`IntEnum` is a subclass of `int`, but `IntEnum.__str__` does not behave like `int.__str__` until 3.11.