### PR TITLE
rfc8785: raise CanonicalizationError on nonstr keys

### DIFF
--- a/src/rfc8785/_impl.py
+++ b/src/rfc8785/_impl.py
@@ -233,7 +233,11 @@ def dump(obj: _Value, sink: typing.IO[bytes]) -> None:
         # RFC 8785 3.2.3: Objects are sorted by key; keys are ordered
         # by their UTF-16 encoding. The spec isn't clear about which endianness,
         # but the examples imply that the big endian encoding is used.
-        obj_sorted = sorted(obj.items(), key=lambda kv: kv[0].encode("utf-16be"))
+        try:
+            obj_sorted = sorted(obj.items(), key=lambda kv: kv[0].encode("utf-16be"))
+        except AttributeError:
+            # Failing to call `encode()` indicates that a key isn't a string.
+            raise CanonicalizationError("object keys must be strings")
 
         sink.write(b"{")
         for idx, (key, value) in enumerate(obj_sorted):

--- a/test/test_impl.py
+++ b/test/test_impl.py
@@ -127,3 +127,8 @@ def test_dumps_strenum():
 
     raw = impl.dumps([X.A, X.B, X.C])
     assert json.loads(raw) == ["foo", "bar", "baz"]
+
+
+def test_dumps_nonstring_key():
+    with pytest.raises(impl.CanonicalizationError, match="object keys must be strings"):
+        impl.dumps({1: 2, None: 3})


### PR DESCRIPTION
These would previously leak an `AttributeError`. Catching the `AttributeError` isn't the cleanest thing, but it saves us another iteration.