### PR TITLE
Enable more mypy check options

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ include = ["test"]
 [tool.mypy]
 mypy_path = "src"
 packages = "rfc8785"
-allow_redefinition = true
 check_untyped_defs = true
 disallow_incomplete_defs = true
 disallow_untyped_defs = true
@@ -54,13 +53,20 @@ ignore_missing_imports = true
 no_implicit_optional = true
 show_error_codes = true
 sqlite_cache = true
+strict = true
 strict_equality = true
+strict_equality_for_none = true
 warn_no_return = true
 warn_redundant_casts = true
 warn_return_any = true
 warn_unreachable = true
 warn_unused_configs = true
 warn_unused_ignores = true
+
+[[tool.mypy.overrides]]
+module = "test.*"
+disallow_untyped_defs = false
+disallow_incomplete_defs = false
 
 [tool.ruff]
 line-length = 100

--- a/src/rfc8785/_impl.py
+++ b/src/rfc8785/_impl.py
@@ -81,7 +81,7 @@ def _serialize_str(s: str, sink: typing.IO[bytes]) -> None:
     Serialize a string as a JSON string, per RFC 8785 3.2.2.2.
     """
 
-    def _replace(match: re.Match) -> str:
+    def _replace(match: re.Match[str]) -> str:
         return _ESCAPE_DCT[match.group(0)]
 
     sink.write(b'"')

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -16,7 +16,7 @@ def vector() -> Callable[[str], tuple[bytes, bytes, bytes]]:
         output = _ASSETS / f"output/{name}.json"
         outhex = _ASSETS / f"outhex/{name}.txt"
 
-        return (input.read_bytes(), output.read_bytes(), bytearray.fromhex(outhex.read_text()))
+        return (input.read_bytes(), output.read_bytes(), bytes.fromhex(outhex.read_text()))
 
     return _vector
 

--- a/test/test_impl.py
+++ b/test/test_impl.py
@@ -102,7 +102,7 @@ def test_string_invalid_utf8():
 def test_dumps_invalid_type():
     with pytest.raises(impl.CanonicalizationError):
         # set is not serializable
-        impl.dumps({1, 2, 3})
+        impl.dumps({1, 2, 3})  # type: ignore[arg-type]
 
 
 def test_dumps_intenum():
@@ -141,7 +141,7 @@ def test_dumps_enum_multiple_inheritance():
     assert json.loads(raw) == ["foo", "bar", "baz"]
 
     # Same for other JSON-able enum types.
-    class Y(dict, Enum):
+    class Y(dict[str, str], Enum):  # type: ignore[misc]
         A = {"A": "foo"}
         B = {"B": "bar"}
         C = {"C": "baz"}
@@ -166,9 +166,9 @@ def test_dumps_bare_enum_fails():
 
     # Python's json doesn't allow this, so we don't either.
     with pytest.raises(impl.CanonicalizationError, match="unsupported type"):
-        impl.dumps([X.A, X.B, X.C])
+        impl.dumps([X.A, X.B, X.C])  # type: ignore[list-item]
 
 
 def test_dumps_nonstring_key():
     with pytest.raises(impl.CanonicalizationError, match="object keys must be strings"):
-        impl.dumps({1: 2, None: 3})
+        impl.dumps({1: 2, None: 3})  # type: ignore[dict-item]


### PR DESCRIPTION
- Add re.Match type parameter
- Add type for dict
- Add type ignore for tests that intentionally put wrong type