### PR TITLE
workflows: Add Python 3.13 and 3.14 to test platforms

### DIFF
--- a/.github/workflows/float-tests.yml
+++ b/.github/workflows/float-tests.yml
@@ -18,6 +18,8 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
+          - "3.14"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,8 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
+          - "3.14"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Add Python 3.13 and 3.14 to test platforms for:
- float tests
- unit tests